### PR TITLE
Add support for Semistandard as well

### DIFF
--- a/eslint/debug.log
+++ b/eslint/debug.log
@@ -1,2 +1,0 @@
-[0210/103838:ERROR:tcp_listen_socket.cc(76)] Could not bind socket to 127.0.0.1:6004
-[0210/103838:ERROR:node_debugger.cc(86)] Cannot start debugger server

--- a/eslint/extension.ts
+++ b/eslint/extension.ts
@@ -291,9 +291,10 @@ export function realActivate(context: ExtensionContext) {
 					context.globalState.update(key, state);
 				}
 			} else {
+				const style = workspace.getConfiguration('standard').semistandard ? 'semistandard' : 'standard';
 				client.info([
 					`Failed to load the JavaScript Standard Style library for the document '${uri.fsPath}'.`,
-					'To use JavaScript Standard Style for single JavaScript file install standard globally using \'npm install -g standard\'.',
+					`To use JavaScript ${style.charAt(0).toUpperCase().concat(style.substr(1))} Style for single JavaScript file install ${style} globally using 'npm install -g ${style}'.`,
 					'You need to reopen VS Code after installing standard.',
 				].join('\n'));
 				if (!state.global) {

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -52,6 +52,11 @@
           "default": {},
           "description": "The JavaScript Standard Style options object to provide args normally passed to JavaScript Standard Style when executed from a command line."
         },
+        "standard.semistandard": {
+          "type": "boolan",
+          "default": false,
+          "description": "Controls whether JavaScript Semistandard Style should be allowed or not."
+        },
         "standard.trace.server": {
           "type": "string",
           "enum": [


### PR DESCRIPTION
I noticed that the Atom package for [Standard](https://atom.io/packages/linter-js-standard) also allows to use SEMIStandard as well. I think this is a good thing to have in the VSCode extension and I don't think creating a whole new extension is worth it, yours is already great! 😉 