### PR TITLE
Add support for package.json inspection.

### DIFF
--- a/eslint-server/src/server.ts
+++ b/eslint-server/src/server.ts
@@ -350,20 +350,23 @@ documents.onDidOpen((event) => {
 	let pkgOptions
 	if (usePackageJson) {
 		const pkgPath = path.join(workspaceRoot, 'package.json');
-		const pkgStr = fs.readFileSync(pkgPath, 'utf8');
-		const pkg = JSON.parse(pkgStr);
-		if (pkg && pkg.devDependencies && pkg.devDependencies.standard) {
-			pkgStyle = 'standard';
-		} else if (pkg && pkg.devDependencies && pkg.devDependencies.semistandard) {
-			pkgStyle = 'semistandard';
-		}
-
-		if (pkgStyle) {
-			pkgOptions = pkg[pkgStyle];
-		} else {
-			connection.console.info('no standard in package.json');
-			return;
-		}
+		const pkgExists = fs.existsSync(pkgPath);
+		if (pkgExists) {
+			const pkgStr = fs.readFileSync(pkgPath, 'utf8');
+			const pkg = JSON.parse(pkgStr);
+			if (pkg && pkg.devDependencies && pkg.devDependencies.standard) {
+				pkgStyle = 'standard';
+			} else if (pkg && pkg.devDependencies && pkg.devDependencies.semistandard) {
+				pkgStyle = 'semistandard';
+			}
+	
+			if (pkgStyle) {
+				pkgOptions = pkg[pkgStyle];
+			} else {
+				connection.console.info('no standard in package.json');
+				return;
+			}
+		}		
 	}
 
 	let style = settings.standard.semistandard ? 'semistandard' : 'standard';

--- a/eslint-server/src/server.ts
+++ b/eslint-server/src/server.ts
@@ -19,7 +19,7 @@ import {
 
 import Uri from 'vscode-uri';
 import path = require('path');
-import readFileSync = require('fs');
+import fs = require('fs');
 const deglob = require('deglob');
 namespace Is {
 	const toString = Object.prototype.toString;
@@ -134,6 +134,7 @@ interface Settings {
 		semistandard?: boolean;
 		validate?: (string | ValidateItem)[];
 		workingDirectories?: (string | DirectoryItem)[];
+		usePackageJson?: boolean;
 	}
 	[key: string]: any;
 }
@@ -344,35 +345,35 @@ documents.onDidOpen((event) => {
 	if (!supportedLanguages[event.document.languageId]) {
 		return;
 	}
-	const usePackageJSON = settings.standard.usePackageJSON;
-    let pkgStyle
-    let pkgOptions
-    if (usePackageJSON) {
-        const pkgPath = path.join(workspaceRoot, 'package.json');
-        const pkgStr = readFileSync(pkgPath, 'utf8');
-        const pkg = JSON.parse(pkgStr);
-        if (pkg && pkg.devDependencies && pkg.devDependencies.standard) {
-            pkgStyle = 'standard';
-        } else if (pkg && pkg.devDependencies && pkg.devDependencies.semistandard) {
-            pkgStyle = 'semistandard';
+	const usePackageJson = settings.standard.usePackageJson;
+	let pkgStyle
+	let pkgOptions
+	if (usePackageJson) {
+		const pkgPath = path.join(workspaceRoot, 'package.json');
+		const pkgStr = fs.readFileSync(pkgPath, 'utf8');
+		const pkg = JSON.parse(pkgStr);
+		if (pkg && pkg.devDependencies && pkg.devDependencies.standard) {
+			pkgStyle = 'standard';
+		} else if (pkg && pkg.devDependencies && pkg.devDependencies.semistandard) {
+			pkgStyle = 'semistandard';
 		}
-		
-        if (pkgStyle) {
-            pkgOptions = pkg[pkgStyle];
-        } else {
-            connection.console.info('no standard in package.json');
-            return;
-        }
+
+		if (pkgStyle) {
+			pkgOptions = pkg[pkgStyle];
+		} else {
+			connection.console.info('no standard in package.json');
+			return;
+		}
 	}
 
-    let style = settings.standard.semistandard ? 'semistandard' : 'standard';
-    if (pkgStyle) {
-        style = pkgStyle;
-    }
-    if (pkgOptions) {
-        options = pkgOptions;
+	let style = settings.standard.semistandard ? 'semistandard' : 'standard';
+	if (pkgStyle) {
+		style = pkgStyle;
 	}
-	
+	if (pkgOptions) {
+		options = pkgOptions;
+	}
+
 	if (!document2Library[event.document.uri]) {
 		let uri = Uri.parse(event.document.uri);
 		let promise: Thenable<string>

--- a/eslint-server/src/server.ts
+++ b/eslint-server/src/server.ts
@@ -19,6 +19,7 @@ import {
 
 import Uri from 'vscode-uri';
 import path = require('path');
+import readFileSync = require('fs');
 const deglob = require('deglob');
 namespace Is {
 	const toString = Object.prototype.toString;
@@ -343,7 +344,35 @@ documents.onDidOpen((event) => {
 	if (!supportedLanguages[event.document.languageId]) {
 		return;
 	}
-	const style = settings.standard.semistandard ? 'semistandard' : 'standard';
+	const usePackageJSON = settings.standard.usePackageJSON;
+    let pkgStyle
+    let pkgOptions
+    if (usePackageJSON) {
+        const pkgPath = path.join(workspaceRoot, 'package.json');
+        const pkgStr = readFileSync(pkgPath, 'utf8');
+        const pkg = JSON.parse(pkgStr);
+        if (pkg && pkg.devDependencies && pkg.devDependencies.standard) {
+            pkgStyle = 'standard';
+        } else if (pkg && pkg.devDependencies && pkg.devDependencies.semistandard) {
+            pkgStyle = 'semistandard';
+		}
+		
+        if (pkgStyle) {
+            pkgOptions = pkg[pkgStyle];
+        } else {
+            connection.console.info('no standard in package.json');
+            return;
+        }
+	}
+
+    let style = settings.standard.semistandard ? 'semistandard' : 'standard';
+    if (pkgStyle) {
+        style = pkgStyle;
+    }
+    if (pkgOptions) {
+        options = pkgOptions;
+	}
+	
 	if (!document2Library[event.document.uri]) {
 		let uri = Uri.parse(event.document.uri);
 		let promise: Thenable<string>

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -131,6 +131,11 @@
             "javascriptreact"
           ],
           "description": "An array of language ids which should be validated by JavaScript Standard Style"
+        },
+        "standard.usePackageJson": {
+          "type": "boolean",
+          "default": false,
+          "description": "Activate only if present in package.json and use settings specified there."
         }
       }
     },


### PR DESCRIPTION
Just wanted to open a PR to start a discussion on how to address #21. 
* Adds `usePackageJson` boolean setting which defaults to `false` keeping the existing functionality the same for all clients with no changes required. 
* I tried this locally by editing the extension file directly with the same code and it seems to be working. At least it doesn't try to lint files when the setting is `true` and `standard` or `semistandard` is in `devDependencies`.
* I am not sure if this is the correct approach and would appreciate feedback.
* I was not able to build this properly using `npm run vscode:prepublish` and got what I believe typescript / linting errors regarding code I did not touch. So not sure what to do about that.
* Also not sure what the best approach is for testing it besides manually testing.