### PR TITLE
Add support for standardx, and potentially more standard-engine based linters

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"taskName": "watch",
+			"label": "watch",
 			"dependsOn": [
 				"npm: watch:client",
 				"npm: watch:server"
@@ -16,6 +16,7 @@
 			"problemMatcher": []
 		},
 		{
+			"label": "npm: watch:client",
 			"type": "npm",
 			"script": "watch:client",
 			"isBackground": true,
@@ -28,6 +29,7 @@
 			]
 		},
 		{
+			"label": "npm: watch:server",
 			"type": "npm",
 			"script": "watch:server",
 			"isBackground": true,

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ VSCode extension to integrate [JavaScript Standard Style](https://github.com/fer
 
 We support [JavaScript Semi-Standard Style](https://github.com/Flet/semistandard) too, if you prefer keeping the semicolon.
 
+[JavaScript Standard Style with custom tweaks](https://github.com/standard/standardx) is also supported if you want to fine-tune your ESLint config while keeping the power of Standard.
+
 ## How to use
 
 1. **Install the 'JavaScript Standard Style' extension**
@@ -12,7 +14,7 @@ We support [JavaScript Semi-Standard Style](https://github.com/Flet/semistandard
 
 	You will need to reload VSCode before new extensions can be used.
 
-2. **Install `standard` or `semistandard`**
+2. **Install `standard`, `semistandard` or `standardx`**
 
 	This can be done globally or locally. We recommend that you install them locally (i.e. saved in your project's `devDependencies`), to ensure that other developers have it installed when working on the project.
 
@@ -32,7 +34,7 @@ Option|Description|Default
 `standard.nodePath`|use this setting if an installed `standard` package can't be detected.|`null`
 `standard.validate`|an array of language identifiers specify the files to be validated|`["javascript", "javascriptreact"]`
 `standard.workingDirectories`|an array for working directories to be used.|`[]`
-`standard.semistandard`|You can use `semistandard` if you set this option to `true`. **Just make sure you've installed the `semistandard` package, instead of `standard`.**|`false`
+`standard.engine`|You can use `semistandard` or `standardx` instead of `standard`. **Just make sure you've installed the `semistandard` or the `standardx` package, instead of `standard`.**|`standard`
 `standard.usePackageJson`|if set to `true`, JavaScript Standard Style will use project's `package.json` settings, otherwise globally installed `standard` module is used |`false`
 
 

--- a/package.json
+++ b/package.json
@@ -62,11 +62,16 @@
           "default": {},
           "description": "The standard options object to provide args normally passed to JavaScript Standard Style when executed from a command line."
         },
-        "standard.semistandard": {
+        "standard.engine": {
           "scope": "resource",
-          "type": "boolean",
-          "default": false,
-          "description": "Controls whether JavaScript Semistandard Style should be enabled or disabled."
+          "type": "string",
+          "enum": [
+            "standard",
+            "semistandard",
+            "standardx"
+          ],
+          "default": "standard",
+          "description": "Controls whether VSCode should use an alternate Standard engine, like semistandard or standardx."
         },
         "standard.trace.server": {
           "scope": "window",


### PR DESCRIPTION
Hello !

Here's an implementation of `standardx` support in the extension, and potentially easing up the addition of more standard-engine based linters in the future.

For `standardx` itself, the support is working but cannot find the right .eslintrc / eslintConfig in package.json without standard/standard-engine#189, which kinda defeats its purpose.

Have a good day !