### PR TITLE
Added context standardEnabled

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -213,18 +213,18 @@ export function activate(context: ExtensionContext) {
 		}
 	}
 	function configurationChanged() {
-		if (activated) {
-			return;
-		}
-		for (let textDocument of Workspace.textDocuments) {
-			if (shouldBeValidated(textDocument)) {
-				openListener.dispose();
-				configurationListener.dispose();
-				activated = true;
-				realActivate(context);
-				return;
+		if (!activated) {
+			for (let textDocument of Workspace.textDocuments) {
+				if (shouldBeValidated(textDocument)) {
+					openListener.dispose();
+					configurationListener.dispose();
+					activated = true;
+					realActivate(context);
+					break;
+				}
 			}
 		}
+		Commands.executeCommand('setContext', 'standardEnabled', activated);
 	}
 	openListener = Workspace.onDidOpenTextDocument(didOpenTextDocument);
 	configurationListener = Workspace.onDidChangeConfiguration(configurationChanged);


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

I added a clause context to detect if standard is enabled. 

Now for example we can use the context in our key bindings, e.g:

```json
{
    "key": "ctrl+shift+i",
    "command": "standard.executeAutofix",
    "when": "standardEnabled && editorTextFocus && !editorReadonly"
}
```