### PR TITLE
Detect brackets in filename with the correct path

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ install:
   - 'npm install'
 
 script:
-  - 'npm run compile'
+  - 'npm run package'
   - 'npm run lint'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 
-## 1.4.1 - Pending
+## 1.5.0 - Pending
 
+- **Feature**: Add `treatErrorsAsWarnings` to forces all warnings and errors from standard to become warnings
 - **Fix**: Detect brackets in filename ([#126](https://github.com/standard/vscode-standardjs/pull/126) and [#139](https://github.com/standard/vscode-standardjs/pull/139))
-- **Fix**: Use standard cwd option from package.json closest to the linted file ([#140](https://github.com/standard/vscode-standardjs/pull/140))
+- **Fix**: Use `standard` cwd option from package.json closest to the linted file ([#140](https://github.com/standard/vscode-standardjs/pull/140))
 
 ## 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Feature**: Add `treatErrorsAsWarnings` to forces all warnings and errors from standard to become warnings
 - **Fix**: Detect brackets in filename ([#126](https://github.com/standard/vscode-standardjs/pull/126) and [#139](https://github.com/standard/vscode-standardjs/pull/139))
-- **Fix**: Use `standard` cwd option from package.json closest to the linted file ([#140](https://github.com/standard/vscode-standardjs/pull/140))
+- **Fix**: Use `standard` cwd option from package.json closest to the linted file (only if engine is `standard`) ([#140](https://github.com/standard/vscode-standardjs/pull/140))
 
 ## 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.4.1 - Pending
+
+- **Fix**: Detect brackets in filename ([#126](https://github.com/standard/vscode-standardjs/pull/126) and [#139](https://github.com/standard/vscode-standardjs/pull/139))
+
 ## 1.4.0
 
 - **Feature**: Add support for `ts-standard` ([#103](https://github.com/standard/vscode-standardjs/pull/103))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.4.1 - Pending
 
 - **Fix**: Detect brackets in filename ([#126](https://github.com/standard/vscode-standardjs/pull/126) and [#139](https://github.com/standard/vscode-standardjs/pull/139))
+- **Fix**: Use standard cwd option from package.json closest to the linted file ([#140](https://github.com/standard/vscode-standardjs/pull/140))
 
 ## 1.4.0
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
    <a href="https://marketplace.visualstudio.com/items?itemName=chenxsan.vscode-standardjs"><img src="https://vsmarketplacebadge.apphb.com/version/chenxsan.vscode-standardjs.svg" alt="Visual Studio Marketplace" /></a>
    <img alt="Downloads Visual Studio Marketplace" src="https://vsmarketplacebadge.apphb.com/downloads-short/chenxsan.vscode-standardjs.svg" />
    <br/> <br/>
-   <a href="https://standardjs.com"><img src="https://cdn.rawgit.com/standard/standard/master/sticker.svg" alt="Standard - JavaScript Style Guide" width="200"></a>
+   <a href="https://standardjs.com"><img src="https://raw.githubusercontent.com/standard/vscode-standardjs/master/standard_icon.png" alt="Standard - JavaScript Style Guide" width="200"></a>
 </p>
 
 ## How to use

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -888,7 +888,13 @@ function validate (
         ) {
           process.chdir(settings.workingDirectory.directory)
         }
-      } else if (!isUNC(file)) {
+      } else if (settings.workspaceFolder != null && settings.engine !== 'standard') {
+        const workspaceFolderUri = settings.workspaceFolder.uri
+        if (workspaceFolderUri.scheme === 'file') {
+          newOptions.cwd = workspaceFolderUri.fsPath
+          process.chdir(workspaceFolderUri.fsPath)
+        }
+      } else if (settings.workspaceFolder == null && !isUNC(file)) {
         const directory = path.dirname(file)
         if (directory.length > 0) {
           if (path.isAbsolute(directory)) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -115,12 +115,14 @@ interface CLIOptions {
   plugins: string[]
   envs: string[]
   parser: string
+  filename: string
 }
 
 type StandardModuleCallback = (error: Object, results: StanardReport) => void
 interface Opts {
   ignore?: string[]
   cwd?: string
+  filename?: string
 }
 interface StandardModule {
   lintText: (
@@ -902,6 +904,7 @@ function validate (
       }
     }
     if (settings.library != null) {
+      newOptions.filename = file
       var opts = settings.library.parseOpts(newOptions)
       var deglobOpts = {
         ignore: opts.ignore,


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [x] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

- [x] **Fix**: detect brackets in filename by setting `newOptions.filename = file` with the correct path.
For example : `[id].tsx` before the PR, the path was something like that `%5Bid%5B.tsx`, now it is `[id].tsx` as it is expected.
It means custom parser like `@typescript-eslint/parser` used in `ts-standard` for example will not complain because the file does not match the project config.
Thanks to @Geospace report!
- [x] **Docs**: We can't package the extension with `vsce` if the `README.md` contain `img` src tag with `svg` (should only be `png` or `jpg`). Instead to use the cdn used in the https://github.com/standard/standard README, we use directly the logo in the root folder of this project with the GitHub link.
- [x] **CI**: To ensure, we can always package the extension even if the `tsc` compiles, we run `npm run package` instead of only `npm run compile` in the Travis CI. It takes a liitle bit more time but it will not pass when for example we use `svg` instead of `png` in README as it was the case in this PR #136.
- [x] **Docs**: Add `1.4.1` section as pending

 **Which issue (if any) does this pull request address?**

#126 

**Is there anything you'd like reviewers to focus on?**

Steps to reproduce the issue :

- `git clone https://github.com/standard/vscode-standardjs.git`
- `git checkout fix/brackets-filename` 
- `npm install`
- `npm run package`
- `code --install-extension vscode-standardjs-1.4.0.vsix`
- Create a new project with `ts-standard` and `typescript` as `devDependencies` and `.vscode/settings.json` with this content :
```json
{
  "standard.enable": true,
  "standard.engine": "ts-standard",
  "standard.usePackageJson": true
}
```

- Create a new file called `[id].tsx` with this content : 
```tsx
const string = '';
console.log(string)

```

Hopefully, `ts-standard` will show you lint errors cause of the `semicolon` , if it is the case It means the issue has been fixed!

It's working for me as you can see on this screenshot :
![Capture1_11](https://user-images.githubusercontent.com/25207499/100368943-838d2580-3004-11eb-80ef-864ea742910c.png)

If it's not working, feel free to send your file, with your `settings.json` and screenshots are always appreciated so we can investigate and try to fix this issue.