### PR TITLE
Use standard cwd option from package.json closest to the file itself …

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -886,13 +886,7 @@ function validate (
         ) {
           process.chdir(settings.workingDirectory.directory)
         }
-      } else if (settings.workspaceFolder != null) {
-        const workspaceFolderUri = settings.workspaceFolder.uri
-        if (workspaceFolderUri.scheme === 'file') {
-          newOptions.cwd = workspaceFolderUri.fsPath
-          process.chdir(workspaceFolderUri.fsPath)
-        }
-      } else if (settings.workspaceFolder == null && !isUNC(file)) {
+      } else if (!isUNC(file)) {
         const directory = path.dirname(file)
         if (directory.length > 0) {
           if (path.isAbsolute(directory)) {


### PR DESCRIPTION
…instead of package.json on the workspace root folder

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Remove code that passes root workspace directory as 'cwd option' , instead make use the linting file path as 'cwd option' so that standard can use the package.json closer to the file itself / package.json inside the sub-directory

**Which issue (if any) does this pull request address?**
#110 

**Is there anything you'd like reviewers to focus on?**
To test other use cases that is using 'cwd option'
