### PR TITLE
feat: better options default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,7 @@
   "standard.enable": true,
   "standard.engine": "ts-standard",
   "standard.usePackageJson": true,
-  "standard.workingDirectories": ["client", "server"]
+  "standard.workingDirectories": ["client", "server"],
+  "standard.autoFixOnSave": true,
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.0.0
+
+- **Feature**: Better options default to reduce configurations overhead for users so that they can use the extension fast without too much configurations and still following "best practices" by encouraging local installation per project. ([#263](https://github.com/standard/vscode-standard/pull/263))
+
+Now the extension will be automatically be enabled in projects that has one of the engines (`standard`, `semistandard`, `standardx` or `ts-standard`) installed in `devDependencies` in `package.json`.
+
+**Note**: This feature is only working if you have only **one** open folder in your VSCode workspace.
+**Note 2**: If you still want to enable the extension globally you can set the new option : `"standard.enableGlobally": true` (by default it is set to `false`).
+
+**BREAKING CHANGE**: This feature changed the default settings, before: `"standard.usePackageJson": false`, after: `"standard.usePackageJson": true`
+**BREAKING CHANGE**: By default (if you don't set `"standard.enableGlobally": true`), the extension will not lint your files if you haven't got a `package.json` containing one of the engines installed in `devDependencies`.
+
 ## 1.5.1
 
 - **Fix**: Find babel config files with `@babel/eslint-parser` ([#207](https://github.com/standard/vscode-standardjs/pull/207))

--- a/README.md
+++ b/README.md
@@ -15,34 +15,39 @@
 
 ## How to use
 
-1. **Install the 'JavaScript Standard Style' extension**
+1. **Install the 'StandardJS - JavaScript Standard Style' extension**
 
-   If you don't know how to install extensions in VSCode, take a look at the [documentation](https://code.visualstudio.com/docs/editor/extension-gallery#_browse-and-install-extensions).
+   Launch VSCode Quick Open (⌘+P), paste the following command, and press enter.
 
-   You will need to reload VSCode before new extensions can be used.
+   ```text
+   ext install standard.vscode-standard
+   ```
 
-2. **Install `standard`, `semistandard`, `standardx` or `ts-standard`**
+   For more information, take a look at the [documentation](https://code.visualstudio.com/docs/editor/extension-gallery#_browse-and-install-extensions).
+
+2. **Install the engine `standard`, `semistandard`, `standardx` or `ts-standard`**
 
    This can be done globally or locally. We recommend that you install them locally (i.e. saved in your project's `devDependencies`), to ensure that other developers have it installed when working on the project.
 
-3. **Disable the built-in VSCode validator**
+3. **Enable the extension**
 
-   To do this, set `"javascript.validate.enable": false` in your VSCode `settings.json`.
+   That's it! The extension will automatically be enabled in projects that has one of the engines installed in `devDependencies` in `package.json`.
 
-## Plugin options
+## Extension options
 
-We give you some options to customize vscode-standard in your VSCode [`settings.json`](https://code.visualstudio.com/docs/getstarted/settings).
+We give you some options to customize `vscode-standard` in your VSCode [`settings.json`](https://code.visualstudio.com/docs/getstarted/settings).
 
 | Option                           | Description                                                                                                                                                                                                  | Default                                                             |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
 | `standard.enable`                | enable or disable JavaScript Standard Style                                                                                                                                                                  | `true`                                                              |
+| `standard.enableGlobally`        | enable or disable JavaScript Standard Style globally                                                                                                                                                         | `false`                                                             |
 | `standard.run`                   | run linter `onSave` or `onType`                                                                                                                                                                              | `onType`                                                            |
 | `standard.autoFixOnSave`         | enable or disable auto fix on save. It is only available when VSCode's `files.autoSave` is either `off`, `onFocusChange` or `onWindowChange`. It will not work with `afterDelay`.                            | `false`                                                             |
 | `standard.nodePath`              | use this setting if an installed `standard` package can't be detected.                                                                                                                                       | `null`                                                              |
 | `standard.validate`              | an array of language identifiers specify the files to be validated                                                                                                                                           | `["javascript", "javascriptreact", "typescript", "typescriptreact]` |
 | `standard.workingDirectories`    | an array for working directories to be used.                                                                                                                                                                 | `[]`                                                                |
 | `standard.engine`                | You can use `semistandard`, `standardx` or `ts-standard` instead of `standard`. **Just make sure you've installed the `semistandard`, the `standardx` or the `ts-standard` package, instead of `standard`.** | `standard`                                                          |
-| `standard.usePackageJson`        | if set to `true`, JavaScript Standard Style will use project's `package.json` settings, otherwise globally installed `standard` module is used                                                               | `false`                                                             |
+| `standard.usePackageJson`        | if set to `true`, JavaScript Standard Style will use project's `package.json` settings, otherwise globally installed `standard` module is used                                                               | `true`                                                              |
 | `standard.treatErrorsAsWarnings` | Any linting error reported by Standard will instead be displayed as a warning within VS Code.                                                                                                                | `false`                                                             |
 
 ## Configuring Standard

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "client",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
@@ -22,29 +23,43 @@
       }
     },
     "../node_modules/snazzy": {
-      "version": "0.0.1",
+      "version": "9.0.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
         "inherits": "^2.0.4",
         "minimist": "^1.2.5",
         "readable-stream": "^3.6.0",
-        "standard": "*",
         "standard-json": "^1.1.0",
         "strip-ansi": "^6.0.0",
         "text-table": "^0.2.0"
+      },
+      "bin": {
+        "snazzy": "bin/cmd.js"
+      },
+      "devDependencies": {
+        "standard": "*"
       }
     },
     "../node_modules/ts-standard": {
-      "version": "0.0.1",
+      "version": "10.0.0",
+      "license": "MIT",
       "dependencies": {
-        "@commitlint/cli": "^11.0.0",
-        "@commitlint/config-conventional": "^11.0.0",
-        "@types/eslint": "^7.2.5",
-        "@types/jest": "^26.0.15",
-        "@types/minimist": "^1.2.1",
-        "@types/node": "^14.14.10",
         "@typescript-eslint/eslint-plugin": "^4.8.2",
-        "coveralls": "^3.1.0",
         "eslint": "^7.14.0",
         "eslint-config-standard": "^16.0.2",
         "eslint-config-standard-jsx": "^10.0.0",
@@ -55,15 +70,33 @@
         "eslint-plugin-react": "^7.21.5",
         "eslint-plugin-standard": "4.1.0",
         "get-stdin": "^8.0.0",
-        "husky": "^4.3.0",
-        "jest": "^26.6.3",
         "minimist": "^1.2.5",
         "pkg-conf": "^3.1.0",
+        "standard-engine": "^14.0.1"
+      },
+      "bin": {
+        "ts-standard": "bin/cmd.js"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^11.0.0",
+        "@commitlint/config-conventional": "^11.0.0",
+        "@types/eslint": "^7.2.5",
+        "@types/jest": "^26.0.15",
+        "@types/minimist": "^1.2.1",
+        "@types/node": "^14.14.10",
+        "coveralls": "^3.1.0",
+        "husky": "^4.3.0",
+        "jest": "^26.6.3",
         "prettier": "^2.2.1",
-        "standard-engine": "^14.0.1",
         "ts-jest": "^26.4.4",
         "ts-node": "^9.0.0",
         "typescript": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=3.8"
       }
     },
     "node_modules/@types/vscode": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "vscode-standard",
-  "version": "1.5.1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.5.1",
+      "name": "vscode-standard",
+      "version": "2.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-standard",
   "displayName": "StandardJS - JavaScript Standard Style",
   "description": "Visual Studio Code extension for JavaScript Standard Style with automatic fixing.",
-  "version": "1.5.1",
+  "version": "2.0.0",
   "author": "Standard",
   "license": "MIT",
   "repository": {
@@ -43,6 +43,12 @@
           "type": "boolean",
           "default": true,
           "description": "Controls whether JavaScript Standard Style is enabled for JavaScript files or not."
+        },
+        "standard.enableGlobally": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "Controls whether JavaScript Standard Style is enabled globally for JavaScript files or not."
         },
         "standard.nodePath": {
           "scope": "resource",
@@ -161,7 +167,7 @@
         },
         "standard.usePackageJson": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Activate JavaScript Standard Style based on project's package.json settings, use globally installed standard module if set to \"false\""
         },
         "standard.treatErrorsAsWarnings": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "server",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

As explained in #261, this PR reduce configurations overhead for users so that they can use the extension fast without too much configurations and still following "best practices" by encouraging local installation per project.

This PR adds a new option `"standard.enableGlobally"` (`false` by default) to enable the extension for all files even if there is no engines installed in `package.json` in `devDependencies`.

**Which issue (if any) does this pull request address?**

Fixes #261 

**Is there anything you'd like reviewers to focus on?**

**BREAKING CHANGE**: This feature changed the default settings, before: `"standard.usePackageJson": false`, after: `"standard.usePackageJson": true`

**BREAKING CHANGE**: By default (if you don't set `"standard.enableGlobally": true`), the extension will not lint your files if you haven't got a `package.json` containing one of the engines installed in `devDependencies`.

(Easily fixable by editing `.vscode/settings.json`, long time ago we didn't have **BREAKING CHANGE** for this extension so that should be fine)
