### PR TITLE
fix: change working directory prior to loading the engine

### DIFF
--- a/client/src/test/runTests.ts
+++ b/client/src/test/runTests.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
 import * as fs from 'fs'
+import { tmpdir } from 'os'
 import { exec } from 'child_process'
 import { runTests } from '@vscode/test-electron'
 
@@ -43,6 +44,7 @@ async function main (): Promise<void> {
     )
     process.chdir(testWorkspace)
     await execShellCommand('npm install')
+    process.chdir(tmpdir())
     await runTests({
       version: 'stable',
       extensionDevelopmentPath,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -427,8 +427,15 @@ async function resolveSettings (
         async path => {
           let library = path2Library.get(path)
           if (library == null) {
+            // Need to load the library dynamically, making sure CWD is temporarily
+            // set to the target workspace
+            const oldCwd = process.cwd()
+            if (settings.workspaceFolder != null) {
+              process.chdir(settings.workspaceFolder.uri.fsPath)
+            }
             // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
             library = (await Function(`return import('file://${path.replace(/\\/g, '\\\\')}')`)()).default
+            process.chdir(oldCwd)
             if (library?.lintText == null) {
               settings.validate = false
               connection.console.error(


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
The typescript linter (`ts-standard`) needs to find the configuration file (`tsconfig.json` or `tsconfig.eslint.json`) in order to work. It searches, starting from the current working directory. When running the e2e test script and, I suspect, starting VSCode from a Linux shell, the CWD is set correctly and everything works. However this is not guaranteed - for example running from the Windows start menu has the CWD set to the installation directory.

The commit c4d3763d7e5d2e8b723b703cf403aea726e91c9c temporarily changes to the workspace folder before loading the typescript engine and restores the previous value afterwards. The workspace folder seems to be the correct one, at least for single workspace projects.

As mentioned the test code coincidentally sets the CWD correctly so this error never appears when running `npm test`. Commit 663b6fbef57fd923a2e971fdb8ebea743ffbc338 changes to a different directory (actually the temporary directory) prior to starting each test run which causes the `ts-standard` test to fail without the fix also being applied. 


**Which issue (if any) does this pull request address?**
#483 

**Is there anything you'd like reviewers to focus on?**
